### PR TITLE
fix: resolve CLI invocation inconsistency and add -q short flag

### DIFF
--- a/python/pretty_mod/cli.py
+++ b/python/pretty_mod/cli.py
@@ -11,7 +11,9 @@ from ._pretty_mod import display_signature, display_tree
 def main():
     """CLI entry point."""
 
-    parser = argparse.ArgumentParser(description="Module tree exploration CLI")
+    parser = argparse.ArgumentParser(
+        prog="pretty-mod", description="Module tree exploration CLI"
+    )
     subparsers = parser.add_subparsers(dest="command", help="Commands")
 
     tree_parser = subparsers.add_parser("tree", help="Display module tree structure")
@@ -22,6 +24,7 @@ def main():
         "--depth", type=int, default=2, help="Maximum depth to explore (default: 2)"
     )
     tree_parser.add_argument(
+        "-q",
         "--quiet",
         action="store_true",
         help="Suppress warnings and informational messages",
@@ -40,6 +43,7 @@ def main():
         "import_path", help="Import path to the function (e.g., 'json:loads')"
     )
     sig_parser.add_argument(
+        "-q",
         "--quiet",
         action="store_true",
         help="Suppress download messages",


### PR DESCRIPTION
## Summary
- Fixed inconsistent program name display when running `python -m pretty_mod` vs `pretty-mod`
- Added `-q` as a convenient short option for `--quiet` flag in both subcommands

## Details

### Problem
When running the tool as a module (`python -m pretty_mod`), the help text showed `usage: __main__.py` instead of `usage: pretty-mod`. This created an inconsistent user experience between the two invocation methods.

### Solution
Set an explicit `prog='pretty-mod'` parameter in the ArgumentParser constructor to ensure consistent program name display regardless of invocation method.

Additionally, added the `-q` short option for the `--quiet` flag in both the `tree` and `sig` subcommands for improved CLI ergonomics.

## Test plan
- [x] Run `python -m pretty_mod --help` and verify it shows `usage: pretty-mod`
- [x] Run `pretty-mod --help` and verify it still shows `usage: pretty-mod`
- [x] Run `pretty-mod tree -h` and verify `-q` option is shown
- [x] Run `pretty-mod sig -h` and verify `-q` option is shown
- [x] Test that `-q` flag works: `pretty-mod tree json -q`

🤖 Generated with [Claude Code](https://claude.ai/code)